### PR TITLE
F keepcoords ghi45

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,5 +46,5 @@ Remotes:
     poissonconsulting/poisutils
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)

--- a/R/add-z.R
+++ b/R/add-z.R
@@ -15,7 +15,7 @@ ps_sfc_add_z <- function(x, sfc_column = ps_active_sfc_name(x), z_column = "Elev
   x %<>% ps_activate_sfc(sfc_column)
   x %<>% cbind(sf::st_coordinates(x))
 
-  sfg <- do.call(list, purrr::map(1:nrow(x), function(y){
+  sfg <- do.call(list, purrr::map(seq_len(nrow(x)), function(y){
     z <- c(x$X[y], x$Y[y], x[[z_column]][y])
     sfg <- sf::st_point(z, dim = "XYZ")
     sfg

--- a/R/centroid.R
+++ b/R/centroid.R
@@ -26,8 +26,6 @@ ps_sfc_centroid1 <- function(x, sfc_name = ps_active_sfc_name(x), by = character
 
   x %<>% ps_activate_sfc(sfc_name)
 
-  crs <- sf::st_crs(x)
-
   if(!length(by)) {
     suppressWarnings(
       c <- sf::st_combine(x) %>%

--- a/R/coords.R
+++ b/R/coords.R
@@ -90,6 +90,7 @@ ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "
   if (!is.data.frame(x)) ps_error("x must inherit from a data.frame")
   chk_string(sfc_name)
   chk_string(X)
+  chk_flag(retain_orig)
   chk_string(Y)
   chk_string(Z)
 

--- a/R/coords.R
+++ b/R/coords.R
@@ -29,7 +29,7 @@ chk_flag(retain_orig)
 
   x %<>% tibble::as_tibble()
 
-  x$..ID_coords <- 1:nrow(x)
+  x$..ID_coords <- seq_len(nrow(x))
 
   y <- x[!is.na(x[[coords[1]]]) & !is.na(x[[coords[2]]]),]
 
@@ -50,12 +50,12 @@ chk_flag(retain_orig)
       sf::st_cast("POINT")
   }
 
-  if(!retain_orig){
-  y[coords[1]] <- NULL
-  y[coords[2]] <- NULL
-  if(length(coords) == 3L){
-    y[coords[3]] <- NULL
-  }
+  if (!retain_orig) {
+    y[coords[1]] <- NULL
+    y[coords[2]] <- NULL
+    if (length(coords) == 3L) {
+      y[coords[3]] <- NULL
+    }
   }
 
   y[[sfc_name]] <- sfc
@@ -116,8 +116,8 @@ ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "
     x[[Z]] <- coords[,"Z",drop = TRUE]
   }
 
-  if(!retain_orig){
-  x[[sfc_name]] <- NULL
+  if(!retain_orig) {
+    x[[sfc_name]] <- NULL
   }
   x
 }

--- a/R/coords.R
+++ b/R/coords.R
@@ -13,13 +13,15 @@
 ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
                              crs = getOption("ps.crs", 4326),
                              sfc_name = "geometry",
-                             activate = TRUE) {
+                             activate = TRUE,
+                             retain_orig = FALSE) {
   if (!is.data.frame(x)) ps_error("x must inherit from a data.frame")
   chk_vector(coords)
   check_values(coords, "")
   check_dim(coords, values = c(2L:3L))
-  check_names(x, coords)
+  chk::check_names(x, coords)
   chk_string(sfc_name)
+
 
   active_sfc_name <- ps_active_sfc_name(x)
 
@@ -46,10 +48,12 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
       sf::st_cast("POINT")
   }
 
+  if(!retain_orig){
   y[coords[1]] <- NULL
   y[coords[2]] <- NULL
   if(length(coords) == 3L){
     y[coords[3]] <- NULL
+  }
   }
 
   y[[sfc_name]] <- sfc
@@ -79,7 +83,7 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
 #' @param Z A string of the name of the Z coordinate.
 #' @return The modified object with the sfc column removed
 #' @export
-ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "Y", Z = "Z") {
+ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "Y", Z = "Z", retain_orig = FALSE) {
   if (!is.data.frame(x)) ps_error("x must inherit from a data.frame")
   chk_string(sfc_name)
   chk_string(X)
@@ -108,7 +112,8 @@ ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "
     x[[Z]] <- coords[,"Z",drop = TRUE]
   }
 
+  if(!retain_orig){
   x[[sfc_name]] <- NULL
-
+  }
   x
 }

--- a/R/coords.R
+++ b/R/coords.R
@@ -22,7 +22,8 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
   check_dim(coords, values = c(2L:3L))
   chk::check_names(x, coords)
   chk_string(sfc_name)
-
+chk_flag(activate)
+chk_flag(retain_orig)
 
   active_sfc_name <- ps_active_sfc_name(x)
 

--- a/R/coords.R
+++ b/R/coords.R
@@ -20,10 +20,10 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
   chk_vector(coords)
   check_values(coords, "")
   check_dim(coords, values = c(2L:3L))
-  chk::check_names(x, coords)
+  check_names(x, coords)
   chk_string(sfc_name)
-chk_flag(activate)
-chk_flag(retain_orig)
+  chk_flag(activate)
+  chk_flag(retain_orig)
 
   active_sfc_name <- ps_active_sfc_name(x)
 

--- a/R/coords.R
+++ b/R/coords.R
@@ -8,6 +8,7 @@
 #' @param crs An integer with the EPSG code, or character with proj4string.
 #' @param sfc_name A string of the name of the sfc column to create.
 #' @param activate A flag indicating whether to activate the sfc.
+#' #' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.
 #' @return The modified object with the coordinates removed
 #' @export
 ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
@@ -81,6 +82,7 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
 #' @param X A string of the name of the X coordinate.
 #' @param Y A string of the name of the Y coordinate.
 #' @param Z A string of the name of the Z coordinate.
+#' @param retain_orig A a flag indicating if the input coordinates should be retained as columns in the dataframe.
 #' @return The modified object with the sfc column removed
 #' @export
 ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "Y", Z = "Z", retain_orig = FALSE) {

--- a/R/coords.R
+++ b/R/coords.R
@@ -8,7 +8,7 @@
 #' @param crs An integer with the EPSG code, or character with proj4string.
 #' @param sfc_name A string of the name of the sfc column to create.
 #' @param activate A flag indicating whether to activate the sfc.
-#' #' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.
+#' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.
 #' @return The modified object with the coordinates removed
 #' @export
 ps_coords_to_sfc <- function(x, coords = c("X", "Y"),

--- a/R/elevation.R
+++ b/R/elevation.R
@@ -18,7 +18,7 @@ ps_elevation_google <- function(x, sfc_name = ps_active_sfc_name(x),
     x[[Z]] <- numeric(0)
     return(x)
   }
-  y$..RowID <- 1:nrow(y)
+  y$..RowID <- seq_len(nrow(y))
   z <- y[!is.na(y$Latitude) & !is.na(y$Longitude),]
   if(!nrow(z)) {
     x[[Z]] <- NA_real_

--- a/R/load.R
+++ b/R/load.R
@@ -8,7 +8,7 @@
 #' @param rename A function that is used to rename files (after removing extension .csv) before they are passed to make.names.
 #' @param envir The environment to assign the data frames.
 #' @param fun A function that is applied to all sf objects before they are assigned to envir.
-#' @param ... Additional arguments passed to \code{st_read}.
+#' @param ... Additional arguments passed to `st_read`.
 #' @return An invisible character vector of the file names.
 #' @export
 ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
@@ -79,7 +79,7 @@ ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
 #' @param rename A function that is used to rename files (after removing extension .csv) before they are passed to make.names.
 #' @param envir The environment to assign the data frames.
 #' @param fun A function that is applied to all sf objects before they are assigned to envir.
-#' @param ... Additional arguments passed to \code{st_read}.
+#' @param ... Additional arguments passed to `st_read`.
 #' @return An invisible character vector of the layer names.
 #' @export
 ps_load_spatial_db <- function(path = "~/Poisson/Data/spatial/fwa/gdb/FWA_BC.gdb", layers = NULL, crs = NULL, rename = identity,

--- a/R/transform.R
+++ b/R/transform.R
@@ -30,7 +30,7 @@ ps_batch_transform <- function(in_dir, out_dir,
 
   pb <- txtProgressBar(min = 0, max = length(filex), style = 3)
 
-  purrr::walk(1:length(filex), function(x){
+  purrr::walk(seq_len(length(filex)), function(x){
 
     setTxtProgressBar(pb, x)
     message("Processing ", length(filex), " files.")

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 [![Lifecycle:
@@ -16,10 +15,8 @@ data.
 
 ## Installation
 
-``` r
-# install.packages("remotes")
-remotes::install_github("poissonconsulting/poisspatial")
-```
+    # install.packages("remotes")
+    remotes::install_github("poissonconsulting/poisspatial")
 
 ## Contribution
 

--- a/man/ps_coords_to_sfc.Rd
+++ b/man/ps_coords_to_sfc.Rd
@@ -9,7 +9,8 @@ ps_coords_to_sfc(
   coords = c("X", "Y"),
   crs = getOption("ps.crs", 4326),
   sfc_name = "geometry",
-  activate = TRUE
+  activate = TRUE,
+  retain_orig = FALSE
 )
 }
 \arguments{
@@ -21,7 +22,8 @@ ps_coords_to_sfc(
 
 \item{sfc_name}{A string of the name of the sfc column to create.}
 
-\item{activate}{A flag indicating whether to activate the sfc.}
+\item{activate}{A flag indicating whether to activate the sfc.
+#' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.}
 }
 \value{
 The modified object with the coordinates removed

--- a/man/ps_coords_to_sfc.Rd
+++ b/man/ps_coords_to_sfc.Rd
@@ -22,8 +22,9 @@ ps_coords_to_sfc(
 
 \item{sfc_name}{A string of the name of the sfc column to create.}
 
-\item{activate}{A flag indicating whether to activate the sfc.
-#' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.}
+\item{activate}{A flag indicating whether to activate the sfc.}
+
+\item{retain_orig}{A flag indicating if the input coordinates should be retained as columns in the dataframe.}
 }
 \value{
 The modified object with the coordinates removed

--- a/man/ps_longlat_to_sfc.Rd
+++ b/man/ps_longlat_to_sfc.Rd
@@ -11,8 +11,7 @@ ps_longlat_to_sfc(x, sfc_name = "geometry", activate = TRUE)
 
 \item{sfc_name}{A string of the name of the sfc column to create.}
 
-\item{activate}{A flag indicating whether to activate the sfc.
-#' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.}
+\item{activate}{A flag indicating whether to activate the sfc.}
 }
 \value{
 The modified object with Longitude and Latitude removed

--- a/man/ps_longlat_to_sfc.Rd
+++ b/man/ps_longlat_to_sfc.Rd
@@ -11,7 +11,8 @@ ps_longlat_to_sfc(x, sfc_name = "geometry", activate = TRUE)
 
 \item{sfc_name}{A string of the name of the sfc column to create.}
 
-\item{activate}{A flag indicating whether to activate the sfc.}
+\item{activate}{A flag indicating whether to activate the sfc.
+#' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.}
 }
 \value{
 The modified object with Longitude and Latitude removed

--- a/man/ps_sfc_to_coords.Rd
+++ b/man/ps_sfc_to_coords.Rd
@@ -9,7 +9,8 @@ ps_sfc_to_coords(
   sfc_name = ps_active_sfc_name(x),
   X = "X",
   Y = "Y",
-  Z = "Z"
+  Z = "Z",
+  retain_orig = FALSE
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ ps_sfc_to_coords(
 \item{Y}{A string of the name of the Y coordinate.}
 
 \item{Z}{A string of the name of the Z coordinate.}
+
+\item{retain_orig}{A a flag indicating if the input coordinates should be retained as columns in the dataframe.}
 }
 \value{
 The modified object with the sfc column removed

--- a/tests/testthat/test-coords.R
+++ b/tests/testthat/test-coords.R
@@ -20,7 +20,6 @@ test_that("ps_coords_to_sfc retain_orig flag keeps input columns when TRUE", {
 
   expect_identical(x$X, y$X)
   expect_identical(x$Y, y$Y)
-
 })
 
 test_that("ps_coords_to_sfc retain_orig flag drops input columns when FALSE", {
@@ -31,7 +30,6 @@ test_that("ps_coords_to_sfc retain_orig flag drops input columns when FALSE", {
 
   expect_identical(is.null(y$X), TRUE)
   expect_identical(is.null(y$Y), TRUE)
-
 })
 
 test_that("ps_sfc_to_coords retain_orig flag keeps input column when TRUE", {
@@ -39,7 +37,6 @@ test_that("ps_sfc_to_coords retain_orig flag keeps input column when TRUE", {
   x$Row <- 2:4
 
   y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = TRUE)
-
   Y2 <- ps_sfc_to_coords(y[,"geometry"], sfc_name = "geometry", retain_orig = TRUE)
 
   expect_identical(y$geometry, Y2$geometry)

--- a/tests/testthat/test-coords.R
+++ b/tests/testthat/test-coords.R
@@ -11,3 +11,46 @@ test_that("ps_coords_to_sfc when missnig values", {
   expect_identical(y2$geometry[[2]], structure(c(NA_real_, NA_real_), class = c("XY", "POINT", "sfg"
   )))
 })
+
+test_that("ps_coords_to_sfc retain_orig flag keeps input columns when TRUE", {
+  x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
+  x$Row <- 2:4
+
+  y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = TRUE)
+
+  expect_identical(x$X, y$X)
+  expect_identical(x$Y, y$Y)
+
+})
+
+test_that("ps_coords_to_sfc retain_orig flag drops input columns when FALSE", {
+  x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
+  x$Row <- 2:4
+
+  y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = FALSE)
+
+  expect_identical(is.null(y$X), TRUE)
+  expect_identical(is.null(y$Y), TRUE)
+
+})
+
+test_that("ps_sfc_to_coords retain_orig flag keeps input column when TRUE", {
+  x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
+  x$Row <- 2:4
+
+  y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = TRUE)
+
+  Y2 <- ps_sfc_to_coords(y[,"geometry"], sfc_name = "geometry", retain_orig = TRUE)
+
+  expect_identical(y$geometry, Y2$geometry)
+})
+
+test_that("ps_sfc_to_coords retain_orig flag keeps input column when TRUE", {
+  x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
+  x$Row <- 2:4
+
+  y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = FALSE)
+
+  expect_identical(is.null(y$X), TRUE)
+  expect_identical(is.null(y$Y), TRUE)
+})

--- a/tests/testthat/test-nearest.R
+++ b/tests/testthat/test-nearest.R
@@ -2,7 +2,7 @@ test_that("nearest data.frame 1", {
 
   x <- data.frame(Date = ISOdate(2000, 1, c(1, 4, 9)))
   y <- data.frame(Date = ISOdate(2000, 1, c(2, 6, 12)))
-  y$Row <- 1:nrow(x)
+  y$Row <- seq_len(nrow(x))
   y$Row2 <- y$Row + 1.5
 
   n <- ps_nearest(x, y, "Date")
@@ -17,7 +17,7 @@ test_that("nearest tbl_df 1", {
 
   x <- tibble::tibble(Date = ISOdate(2000, 1, c(9, 1, 4)))
   y <- data.frame(Date = ISOdate(2000, 1, c(12, 5, 6)))
-  y$Row <- 1:nrow(x)
+  y$Row <- seq_len(nrow(x))
 
   n <- ps_nearest(x, y, "Date", dist_col = "Distance")
   expect_identical(class(n), c("tbl_df", "tbl", "data.frame"))
@@ -43,7 +43,7 @@ test_that("nearest sf", {
   x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
   y <- data.frame(X = c(1,4.5,5,6), Y = c(1,5,4,6))
 
-  y$Row <- 1:nrow(y)
+  y$Row <- seq_len(nrow(y))
 
   x <- sf::st_as_sf(x, coords = c("X", "Y"), crs = 28992)
   y <- sf::st_as_sf(y, coords = c("X", "Y"), crs = 28992)
@@ -63,7 +63,7 @@ test_that("nearest sf with data.frame", {
   x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
   y <- data.frame(X = c(1,4.5,5,6), Y = c(1,5,4,6))
 
-  y$Row <- 1:nrow(y)
+  y$Row <- seq_len(nrow(y))
 
   x <- sf::st_as_sf(x, coords = c("X", "Y"), crs = 28992)
 
@@ -78,7 +78,7 @@ test_that("nearest sf with X and Y and reprojection", {
   x <- data.frame(X = c(1,1,10), Y = c(1,10,1))
   y <- data.frame(X = c(1,4.5,5,6), Y = c(1,5,4,6))
 
-  y$Row <- 1:nrow(y)
+  y$Row <- seq_len(nrow(y))
 
   x <- sf::st_as_sf(x, coords = c("X", "Y"), crs = 28992)
   y <- sf::st_as_sf(y, coords = c("X", "Y"), crs = 28992)


### PR DESCRIPTION
Fixes issue #45 allowing user to retain original input columns when converting coordinates to sfc or sfc to coordinates. We often need to include easting/northings as well as geometry. This functionality removes necessity to make copies of those columns before converting.  
