### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^LICENSE\.md$
 ^_pkgdown\.yml$
 ^README\.Rmd$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/add-z.R
+++ b/R/add-z.R
@@ -10,16 +10,29 @@
 #' @param remove_z A logical indicating whether to remove the z_column after modifying sfc_column.
 #' @return The modified object.
 #' @export
-ps_sfc_add_z <- function(x, sfc_column = ps_active_sfc_name(x), z_column = "Elevation", new_column = NULL, remove_z = TRUE) {
-  if (identical(sfc_column, character(0))) ps_error("There is no active sfc column. Either activate one or specify the name of an inactive sfc column.")
+ps_sfc_add_z <- function(
+  x,
+  sfc_column = ps_active_sfc_name(x),
+  z_column = "Elevation",
+  new_column = NULL,
+  remove_z = TRUE
+) {
+  if (identical(sfc_column, character(0))) {
+    ps_error(
+      "There is no active sfc column. Either activate one or specify the name of an inactive sfc column."
+    )
+  }
   x %<>% ps_activate_sfc(sfc_column)
   x %<>% cbind(sf::st_coordinates(x))
 
-  sfg <- do.call(list, purrr::map(seq_len(nrow(x)), function(y) {
-    z <- c(x$X[y], x$Y[y], x[[z_column]][y])
-    sfg <- sf::st_point(z, dim = "XYZ")
-    sfg
-  }))
+  sfg <- do.call(
+    list,
+    purrr::map(seq_len(nrow(x)), function(y) {
+      z <- c(x$X[y], x$Y[y], x[[z_column]][y])
+      sfg <- sf::st_point(z, dim = "XYZ")
+      sfg
+    })
+  )
 
   sfc <- sf::st_sfc(sfg, crs = sf::st_crs(x))
 

--- a/R/basemap.R
+++ b/R/basemap.R
@@ -11,7 +11,9 @@ is_pad <- function(x) {
 #' @param x object to test.
 #' @return flag.
 is_raster <- function(x) {
-  inherits(x, "RasterBrick") || inherits(x, "RasterStack") || inherits(x, "RasterLayer")
+  inherits(x, "RasterBrick") ||
+    inherits(x, "RasterStack") ||
+    inherits(x, "RasterLayer")
 }
 
 #' Test if numeric vector is long/lat
@@ -32,9 +34,15 @@ is_longlat_real <- function(x) {
 #' @export
 ps_sfg_rectangle <- function(x) {
   x %<>% as.vector()
-  if (length(x) != 4) ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
+  if (length(x) != 4) {
+    ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
+  }
 
-  mat <- matrix(c(x[1], x[2], x[1], x[4], x[3], x[4], x[3], x[2], x[1], x[2]), ncol = 2, byrow = TRUE)
+  mat <- matrix(
+    c(x[1], x[2], x[1], x[4], x[3], x[4], x[3], x[2], x[1], x[2]),
+    ncol = 2,
+    byrow = TRUE
+  )
   poly <- st_polygon(list(mat))
   poly
 }
@@ -71,10 +79,16 @@ ps_sf_rectangle <- function(x, crs) {
 #' @return modified object.
 #' @export
 ps_pad_bbox <- function(x, pad) {
-  if (length(as.vector(x)) != 4) ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
-  if (!is_pad(pad)) ps_error("pad must be numeric vector with length 1 or 4")
+  if (length(as.vector(x)) != 4) {
+    ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
+  }
+  if (!is_pad(pad)) {
+    ps_error("pad must be numeric vector with length 1 or 4")
+  }
 
-  if (length(pad) == 1L) pad <- rep(pad, 4)
+  if (length(pad) == 1L) {
+    pad <- rep(pad, 4)
+  }
   y <- c(
     x[1] - pad[1],
     x[2] - pad[2],
@@ -95,8 +109,12 @@ ps_pad_bbox <- function(x, pad) {
 #' @return sfc polygon.
 #' @export
 ps_create_bounds <- function(x, pad) {
-  if (!is.sf(x)) ps_error("x must be a sf object")
-  if (!is_pad(pad)) ps_error("pad must be numeric vector with length 1 or 4")
+  if (!is.sf(x)) {
+    ps_error("x must be a sf object")
+  }
+  if (!is_pad(pad)) {
+    ps_error("pad must be numeric vector with length 1 or 4")
+  }
 
   if (is_longlat(x)) {
     y <- ps_sfcs_to_utm(x)
@@ -126,9 +144,26 @@ ps_create_bounds <- function(x, pad) {
 #' @export
 ps_bbox_ggmap <- function(x, source, maptype) {
   x %<>% as.vector()
-  if (length(x) != 4) ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
-  if (!source %in% c("google", "osm", "stamen", "cloudmade")) ps_error("source must be a valid source readable by ggmap.")
-  if (!maptype %in% c("terrain", "terrain-background", "satellite", "roadmap", "hybrid", "watercolor", "toner")) ps_error("maptype must be a valid maptype readable by ggmap.")
+  if (length(x) != 4) {
+    ps_error("as.vector(x) must have length 4 (xmin, ymin, xmax, ymax")
+  }
+  if (!source %in% c("google", "osm", "stamen", "cloudmade")) {
+    ps_error("source must be a valid source readable by ggmap.")
+  }
+  if (
+    !maptype %in%
+      c(
+        "terrain",
+        "terrain-background",
+        "satellite",
+        "roadmap",
+        "hybrid",
+        "watercolor",
+        "toner"
+      )
+  ) {
+    ps_error("maptype must be a valid maptype readable by ggmap.")
+  }
 
   map <- ggmap::get_map(
     location = x,
@@ -144,7 +179,9 @@ ps_bbox_ggmap <- function(x, source, maptype) {
 #' @return raster object.
 #' @export
 ps_ggmap_to_raster <- function(x) {
-  if (!inherits(x, "ggmap")) ps_error("x must be a ggmap object (e.g. from ps_bbox_ggmap)")
+  if (!inherits(x, "ggmap")) {
+    ps_error("x must be a ggmap object (e.g. from ps_bbox_ggmap)")
+  }
 
   map_bbox <- attr(x, "bb")
   .extent <- raster::extent(as.numeric(map_bbox[c(2, 4, 1, 3)]))
@@ -167,7 +204,9 @@ ps_ggmap_to_raster <- function(x) {
 #' ggplot2::geom_point(data = x, aes(x = x, y = y, col = rgb(layer.1/255, layer.2/255, layer.3/255))).
 #' @export
 ps_raster_to_df <- function(x) {
-  if (!is_raster(x)) ps_error("x must be a raster object (e.g. from ps_ggmap_raster)")
+  if (!is_raster(x)) {
+    ps_error("x must be a raster object (e.g. from ps_ggmap_raster)")
+  }
 
   df <- data.frame(raster::rasterToPoints(x))
   df
@@ -186,10 +225,29 @@ ps_raster_to_df <- function(x) {
 #' @return ggmap object.
 #' @export
 ps_sf_ggmap <- function(x, pad, source, maptype) {
-  if (!is.sf(x)) ps_error("x must be a sf object")
-  if (!is_pad(pad)) ps_error("pad must be numeric vector of length 1 or 4")
-  if (!source %in% c("google", "osm", "stamen", "cloudmade")) ps_error("source must be a valid source readable by ggmap.")
-  if (!maptype %in% c("terrain", "terrain-background", "satellite", "roadmap", "hybrid", "watercolor", "toner")) ps_error("maptype must be a valid maptype readable by ggmap.")
+  if (!is.sf(x)) {
+    ps_error("x must be a sf object")
+  }
+  if (!is_pad(pad)) {
+    ps_error("pad must be numeric vector of length 1 or 4")
+  }
+  if (!source %in% c("google", "osm", "stamen", "cloudmade")) {
+    ps_error("source must be a valid source readable by ggmap.")
+  }
+  if (
+    !maptype %in%
+      c(
+        "terrain",
+        "terrain-background",
+        "satellite",
+        "roadmap",
+        "hybrid",
+        "watercolor",
+        "toner"
+      )
+  ) {
+    ps_error("maptype must be a valid maptype readable by ggmap.")
+  }
 
   bbox <- ps_create_bounds(x, pad) %>%
     st_transform(4326) %>%

--- a/R/centroid.R
+++ b/R/centroid.R
@@ -8,8 +8,12 @@
 #' @param nearest A flag indicating whether to return the point closest to the centroid (as opposed to the actual centroid)
 #' @return Sf object of centroid
 #' @export
-ps_sfc_centroid1 <- function(x, sfc_name = ps_active_sfc_name(x), by = character(0),
-                             nearest = FALSE) {
+ps_sfc_centroid1 <- function(
+  x,
+  sfc_name = ps_active_sfc_name(x),
+  by = character(0),
+  nearest = FALSE
+) {
   check_data(x)
   chk_string(sfc_name)
   check_names(x, sfc_name)
@@ -18,7 +22,9 @@ ps_sfc_centroid1 <- function(x, sfc_name = ps_active_sfc_name(x), by = character
   check_names(x, by)
   chk_flag(nearest)
 
-  if (sfc_name %in% by) ps_error("sfc_name cannot be in by")
+  if (sfc_name %in% by) {
+    ps_error("sfc_name cannot be in by")
+  }
 
   if (!all(sf::st_is(x[[sfc_name]], "POINT"))) {
     ps_error("ps_sfcs_centroid1 is only defined for POINT sfc")
@@ -34,8 +40,7 @@ ps_sfc_centroid1 <- function(x, sfc_name = ps_active_sfc_name(x), by = character
     )
     if (nearest) {
       x <- x[sfc_name]
-      c %<>% ps_nearest(x) %>%
-        tibble::as_tibble()
+      c %<>% ps_nearest(x) %>% tibble::as_tibble()
       c <- c[paste0(sfc_name, ".y")]
       names(c) <- sfc_name
       c %<>% ps_activate_sfc(sfc_name = sfc_name)
@@ -44,7 +49,12 @@ ps_sfc_centroid1 <- function(x, sfc_name = ps_active_sfc_name(x), by = character
   }
 
   x %<>%
-    plyr::ddply(by, ps_sfc_centroid1, sfc_name = sfc_name, nearest = nearest) %>%
+    plyr::ddply(
+      by,
+      ps_sfc_centroid1,
+      sfc_name = sfc_name,
+      nearest = nearest
+    ) %>%
     ps_activate_sfc(sfc_name = sfc_name)
 
   x
@@ -72,19 +82,24 @@ ps_sfcs_centroid <- function(x, sfc_names = ps_sfc_names(x), union = TRUE) {
   x <- x[sfc_names] %>%
     tibble::as_tibble()
 
-  if (!ps_equal_crs(x)) ps_error("Sfcs must have same crs.")
-  if (any(purrr::map_lgl(x, is_longlat))) ps_warning("Centroids not accurate for long/lat data.")
+  if (!ps_equal_crs(x)) {
+    ps_error("Sfcs must have same crs.")
+  }
+  if (any(purrr::map_lgl(x, is_longlat))) {
+    ps_warning("Centroids not accurate for long/lat data.")
+  }
 
   crs <- sf::st_crs(x[[sfc_names[1]]])
 
-  suppressWarnings(c <- purrr::map(x, function(y) {
-    y %<>% sf::st_cast("POINT") %>%
-      do.call(rbind, .)
-  }) %>%
-    plyr::ldply() %>%
-    dplyr::select(X = 2, Y = 3) %>%
-    ps_coords_to_sfc(crs = crs) %>%
-    ps_activate_sfc())
+  suppressWarnings(
+    c <- purrr::map(x, function(y) {
+      y %<>% sf::st_cast("POINT") %>% do.call(rbind, .)
+    }) %>%
+      plyr::ldply() %>%
+      dplyr::select(X = 2, Y = 3) %>%
+      ps_coords_to_sfc(crs = crs) %>%
+      ps_activate_sfc()
+  )
 
   if (union) {
     c %<>% sf::st_union()

--- a/R/coords.R
+++ b/R/coords.R
@@ -11,12 +11,17 @@
 #' @param retain_orig A flag indicating if the input coordinates should be retained as columns in the dataframe.
 #' @return The modified object with the coordinates removed
 #' @export
-ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
-                             crs = getOption("ps.crs", 4326),
-                             sfc_name = "geometry",
-                             activate = TRUE,
-                             retain_orig = FALSE) {
-  if (!is.data.frame(x)) ps_error("x must inherit from a data.frame")
+ps_coords_to_sfc <- function(
+  x,
+  coords = c("X", "Y"),
+  crs = getOption("ps.crs", 4326),
+  sfc_name = "geometry",
+  activate = TRUE,
+  retain_orig = FALSE
+) {
+  if (!is.data.frame(x)) {
+    ps_error("x must inherit from a data.frame")
+  }
   chk_vector(coords)
   check_values(coords, "")
   check_dim(coords, values = c(2L:3L))
@@ -43,7 +48,10 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
   if (length(coords) == 3L) {
     y <- y[!is.na(y[[coords[3]]]), ]
 
-    sfc <- matrix(c(y[[coords[1]]], y[[coords[2]]], y[[coords[3]]]), ncol = 3) %>%
+    sfc <- matrix(
+      c(y[[coords[1]]], y[[coords[2]]], y[[coords[3]]]),
+      ncol = 3
+    ) %>%
       sf::st_multipoint(dim = "XYZ") %>%
       sf::st_sfc(crs = crs) %>%
       sf::st_cast("POINT")
@@ -86,19 +94,33 @@ ps_coords_to_sfc <- function(x, coords = c("X", "Y"),
 #' @param retain_orig A a flag indicating if the input coordinates should be retained as columns in the dataframe.
 #' @return The modified object with the sfc column removed
 #' @export
-ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "Y", Z = "Z", retain_orig = FALSE) {
-  if (!is.data.frame(x)) ps_error("x must inherit from a data.frame")
+ps_sfc_to_coords <- function(
+  x,
+  sfc_name = ps_active_sfc_name(x),
+  X = "X",
+  Y = "Y",
+  Z = "Z",
+  retain_orig = FALSE
+) {
+  if (!is.data.frame(x)) {
+    ps_error("x must inherit from a data.frame")
+  }
   chk_string(sfc_name)
   chk_string(X)
   chk_flag(retain_orig)
   chk_string(Y)
   chk_string(Z)
 
-  if (!(class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING", "sfc_POINT", "sfc_MULTIPOINT"))) {
+  if (
+    !(class(x[[sfc_name]])[[1]] %in%
+      c("sfc_LINESTRING", "sfc_MULTILINESTRING", "sfc_POINT", "sfc_MULTIPOINT"))
+  ) {
     ps_error("sfc_name '", sfc_name, "' must be point or linestring")
   }
 
-  if (class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING")) {
+  if (
+    class(x[[sfc_name]])[[1]] %in% c("sfc_LINESTRING", "sfc_MULTILINESTRING")
+  ) {
     x <- st_cast(x, warn = FALSE, "POINT")
   }
 
@@ -106,7 +128,9 @@ ps_sfc_to_coords <- function(x, sfc_name = ps_active_sfc_name(x), X = "X", Y = "
     ps_error("sfc_name '", sfc_name, "' is not an sfc column")
   }
 
-  if (identical(sfc_name, ps_active_sfc_name(x))) x %<>% tibble::as_tibble()
+  if (identical(sfc_name, ps_active_sfc_name(x))) {
+    x %<>% tibble::as_tibble()
+  }
 
   coords <- sf::st_coordinates(x[[sfc_name]])
 

--- a/R/dms.R
+++ b/R/dms.R
@@ -83,8 +83,7 @@ ps_ddm2dd <- function(x) {
 
   negative <- vapply(x, function(x) grepl("^-", x)[1], TRUE)
   is.na(negative) <- vapply(x, function(x) is.na(x[1]), TRUE)
-  x %<>% lapply(function(x) sub("^-", "", x)) %>%
-    lapply(as.numeric)
+  x %<>% lapply(function(x) sub("^-", "", x)) %>% lapply(as.numeric)
   x[!is.na(negative)] %<>% lapply(function(x) x[1] + x[2] / 60)
   x %<>% unlist()
   x[!is.na(negative) & negative] %<>% magrittr::multiply_by(-1)

--- a/R/elevation.R
+++ b/R/elevation.R
@@ -6,13 +6,15 @@
 #' @param key The string of the google maps elevation api key.
 #' @return The sf object with a Z column of the elevation in metres.
 #' @export
-ps_elevation_google <- function(x, sfc_name = ps_active_sfc_name(x),
-                                Z = "Z",
-                                key = Sys.getenv("GOOGLE_MAPS_ELEVATION_API_KEY")) {
+ps_elevation_google <- function(
+  x,
+  sfc_name = ps_active_sfc_name(x),
+  Z = "Z",
+  key = Sys.getenv("GOOGLE_MAPS_ELEVATION_API_KEY")
+) {
   y <- ps_sfc_to_longlat(x, sfc_name = sfc_name) # does checking
   chk::chk_string(key)
   chk_string(Z)
-
 
   if (!nrow(x)) {
     x[[Z]] <- numeric(0)

--- a/R/load.R
+++ b/R/load.R
@@ -11,23 +11,40 @@
 #' @param ... Additional arguments passed to `st_read`.
 #' @return An invisible character vector of the file names.
 #' @export
-ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
-                            crs = NULL, rename = identity,
-                            envir = parent.frame(), fun = identity, ...) {
+ps_load_spatial <- function(
+  dir = ".",
+  pattern = NULL,
+  recursive = FALSE,
+  crs = NULL,
+  rename = identity,
+  envir = parent.frame(),
+  fun = identity,
+  ...
+) {
   chk_string(dir)
   if (!is.null(pattern)) {
     chk_string(pattern)
   }
   chk_flag(recursive)
-  if (!is_crs(crs)) ps_error("must provide a valid crs.")
+  if (!is_crs(crs)) {
+    ps_error("must provide a valid crs.")
+  }
 
-  if (!is.function(rename)) ps_error("rename must be a function")
-  if (!is.function(fun)) ps_error("fun must be a function")
+  if (!is.function(rename)) {
+    ps_error("rename must be a function")
+  }
+  if (!is.function(fun)) {
+    ps_error("fun must be a function")
+  }
 
-  if (!dir.exists(dir)) ps_error("directory '", dir, "' does not exist")
+  if (!dir.exists(dir)) {
+    ps_error("directory '", dir, "' does not exist")
+  }
 
-  file_names <- list.files(dir,
-    pattern = pattern, full.names = TRUE,
+  file_names <- list.files(
+    dir,
+    pattern = pattern,
+    full.names = TRUE,
     recursive = recursive
   )
 
@@ -36,13 +53,14 @@ ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
     return(invisible(character(0)))
   }
 
-  df <- data.frame(file_names,
-    files = basename(file_names)
-  )
+  df <- data.frame(file_names, files = basename(file_names))
   df$ext <- tools::file_ext(df$files)
   df %<>% purrr::modify(as.character)
 
-  df <- df[!df$ext %in% c("sbn", "dbf", "sbx", "shx", "xlsx", "csv", "pdf", "docx", "prj"), ]
+  df <- df[
+    !df$ext %in%
+      c("sbn", "dbf", "sbx", "shx", "xlsx", "csv", "pdf", "docx", "prj"),
+  ]
 
   df$names <- purrr::map2(df$files, df$ext, function(x, y) {
     x %<>% gsub(paste0(".", y), "", .)
@@ -60,13 +78,14 @@ ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
 
   # set crs
   if (!is.null(crs)) {
-    data %<>% purrr::map(function(x) {
-      if (is.na(sf::st_crs(x))) {
-        x %<>% sf::st_set_crs(crs)
-      } else {
-        x <- x
-      }
-    })
+    data %<>%
+      purrr::map(function(x) {
+        if (is.na(sf::st_crs(x))) {
+          x %<>% sf::st_set_crs(crs)
+        } else {
+          x <- x
+        }
+      })
   }
 
   data %<>% purrr::map(fun)
@@ -89,14 +108,31 @@ ps_load_spatial <- function(dir = ".", pattern = NULL, recursive = FALSE,
 #' @param ... Additional arguments passed to `st_read`.
 #' @return An invisible character vector of the layer names.
 #' @export
-ps_load_spatial_db <- function(path = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/FWA_BC.gdb", layers = NULL, crs = NULL, rename = identity,
-                               envir = parent.frame(), fun = identity, ...) {
+ps_load_spatial_db <- function(
+  path = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/FWA_BC.gdb",
+  layers = NULL,
+  crs = NULL,
+  rename = identity,
+  envir = parent.frame(),
+  fun = identity,
+  ...
+) {
   chk_string(path)
-  if (!is_crs(crs)) ps_error("must provide a valid crs.")
-  if (!is.function(rename)) ps_error("rename must be a function")
-  if (!is.function(fun)) ps_error("fun must be a function")
-  if (!file.exists(path)) ps_error(path, "' does not exist.")
-  if (!(tools::file_ext(path) %in% c("gdb", "gpkg", "sqlite"))) ps_error("dir must have extension .gdb, .gpkg, or .sqlite")
+  if (!is_crs(crs)) {
+    ps_error("must provide a valid crs.")
+  }
+  if (!is.function(rename)) {
+    ps_error("rename must be a function")
+  }
+  if (!is.function(fun)) {
+    ps_error("fun must be a function")
+  }
+  if (!file.exists(path)) {
+    ps_error(path, "' does not exist.")
+  }
+  if (!(tools::file_ext(path) %in% c("gdb", "gpkg", "sqlite"))) {
+    ps_error("dir must have extension .gdb, .gpkg, or .sqlite")
+  }
 
   l <- sf::st_layers(path)$name
   if (is.null(layers)) {
@@ -106,7 +142,10 @@ ps_load_spatial_db <- function(path = "~/Poisson/Files - Data/Data/spatial/fwa/g
   }
   # if(!l %in% layers) ps_error("Layers do not exist in geodatabase.")
 
-  g <- purrr::map(layers, ~ tryCatch(sf::st_read(dsn = path, layer = .), error = function(e) NULL))
+  g <- purrr::map(
+    layers,
+    ~ tryCatch(sf::st_read(dsn = path, layer = .), error = function(e) NULL)
+  )
 
   names(g) <- layers %>%
     rename() %>%
@@ -114,13 +153,14 @@ ps_load_spatial_db <- function(path = "~/Poisson/Files - Data/Data/spatial/fwa/g
 
   # set crs
   if (!is.null(crs)) {
-    g %<>% purrr::map(function(x) {
-      if (is.na(sf::st_crs(x))) {
-        x %<>% sf::st_set_crs(crs)
-      } else {
-        x <- x
-      }
-    })
+    g %<>%
+      purrr::map(function(x) {
+        if (is.na(sf::st_crs(x))) {
+          x %<>% sf::st_set_crs(crs)
+        } else {
+          x <- x
+        }
+      })
   }
 
   g %<>% purrr::map(fun)
@@ -137,7 +177,9 @@ ps_load_spatial_db <- function(path = "~/Poisson/Files - Data/Data/spatial/fwa/g
 #' @return A factor of the geodatabase names.
 #' @export
 ps_fwa_gdbs <- function(dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb") {
-  if (!dir.exists(dir)) ps_error("directory '", dir, "' does not exist.")
+  if (!dir.exists(dir)) {
+    ps_error("directory '", dir, "' does not exist.")
+  }
   x <- list.files(dir, full.names = F, recursive = F, pattern = ".gdb")
   x
 }
@@ -149,10 +191,19 @@ ps_fwa_gdbs <- function(dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb") {
 #' The default should not have to be changed.
 #' @return A factor of the layer names within specified geodatabase.
 #' @export
-ps_fwa_layers <- function(gdb = "FWA_BC.gdb", dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/") {
+ps_fwa_layers <- function(
+  gdb = "FWA_BC.gdb",
+  dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/"
+) {
   chk_string(gdb[1])
-  if (!dir.exists(dir)) ps_error("directory '", dir, "' does not exist.")
-  if (all(!gdb %in% ps_fwa_gdbs())) ps_error("That is not a recognised fwa geodatabase. See ps_fwa_gdbs() for options.")
+  if (!dir.exists(dir)) {
+    ps_error("directory '", dir, "' does not exist.")
+  }
+  if (all(!gdb %in% ps_fwa_gdbs())) {
+    ps_error(
+      "That is not a recognised fwa geodatabase. See ps_fwa_gdbs() for options."
+    )
+  }
   x <- purrr::map(gdb, ~ sf::st_layers(dsn = paste0(dir, .))[[1]]) %>%
     unlist() %>%
     unique()
@@ -165,8 +216,13 @@ ps_fwa_layers <- function(gdb = "FWA_BC.gdb", dir = "~/Poisson/Files - Data/Data
 #' @param gdb A character string vector indicating FWA geodatabases to extract layer shortcuts from.
 #' @return A factor of the layer names within specified geodatabase.
 #' @export
-ps_fwa_shortcuts <- function(gdb = "FWA_BC.gdb", dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/") {
-  if (all(!gdb %in% ps_fwa_gdbs())) ps_error("gdb is not a valid geodatabase.")
+ps_fwa_shortcuts <- function(
+  gdb = "FWA_BC.gdb",
+  dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/"
+) {
+  if (all(!gdb %in% ps_fwa_gdbs())) {
+    ps_error("gdb is not a valid geodatabase.")
+  }
   x <- ps_fwa_layers(gdb = gdb)
   ex <- grep("_max|_fwa|50K|CODES", x, value = T)
   x <- setdiff(x, ex) %>%
@@ -186,20 +242,43 @@ ps_fwa_shortcuts <- function(gdb = "FWA_BC.gdb", dir = "~/Poisson/Files - Data/D
 #' @param layer A character string indicating which layer to read. See ps_fwa_layers() for options.
 #' @return sf object.
 #' @export
-ps_read_fwa <- function(shortcut = NULL, gdb = "FWA_BC.gdb",
-                        layer = "FWA_COASTLINES_SP", dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/") {
-  if (length(gdb) != 1L) ps_error("Please select one geodatabase to read.")
-  if (length(layer) != 1L) ps_error("Please select one layer to read.")
+ps_read_fwa <- function(
+  shortcut = NULL,
+  gdb = "FWA_BC.gdb",
+  layer = "FWA_COASTLINES_SP",
+  dir = "~/Poisson/Files - Data/Data/spatial/fwa/gdb/"
+) {
+  if (length(gdb) != 1L) {
+    ps_error("Please select one geodatabase to read.")
+  }
+  if (length(layer) != 1L) {
+    ps_error("Please select one layer to read.")
+  }
   chk_string(layer)
   chk_string(gdb)
-  if (!dir.exists(dir)) ps_error("directory '", dir, "' does not exist.")
-  if (!gdb %in% ps_fwa_gdbs()) ps_error("That is not a recognised fwa geodatabase. See ps_fwa_gdbs() for options.")
-  if (all(!layer %in% ps_fwa_layers(gdb = gdb))) ps_error("That layer does not exist in the specified geodatabase. See ps_fwa_layers() for options.")
+  if (!dir.exists(dir)) {
+    ps_error("directory '", dir, "' does not exist.")
+  }
+  if (!gdb %in% ps_fwa_gdbs()) {
+    ps_error(
+      "That is not a recognised fwa geodatabase. See ps_fwa_gdbs() for options."
+    )
+  }
+  if (all(!layer %in% ps_fwa_layers(gdb = gdb))) {
+    ps_error(
+      "That layer does not exist in the specified geodatabase. See ps_fwa_layers() for options."
+    )
+  }
 
   if (!is.null(shortcut)) {
     chk_string(shortcut)
-    if (!shortcut %in% ps_fwa_shortcuts(gdb = ps_fwa_gdbs())) ps_error("Shortcut is not valid. See ps_fwa_shortcuts() for options.")
-    layer <- c(paste0("fwa_", shortcut, "_poly"), paste0("fwa_", shortcut, "_sp")) %>%
+    if (!shortcut %in% ps_fwa_shortcuts(gdb = ps_fwa_gdbs())) {
+      ps_error("Shortcut is not valid. See ps_fwa_shortcuts() for options.")
+    }
+    layer <- c(
+      paste0("fwa_", shortcut, "_poly"),
+      paste0("fwa_", shortcut, "_sp")
+    ) %>%
       toupper()
     all <- ps_fwa_layers(gdb = ps_fwa_gdbs())
     layer <- layer[layer %in% all]

--- a/R/longlat.R
+++ b/R/longlat.R
@@ -7,7 +7,13 @@
 #' @return The modified object with Longitude and Latitude removed
 #' @export
 ps_longlat_to_sfc <- function(x, sfc_name = "geometry", activate = TRUE) {
-  ps_coords_to_sfc(x, coords = c("Longitude", "Latitude"), crs = 4326, sfc_name = sfc_name, activate = activate)
+  ps_coords_to_sfc(
+    x,
+    coords = c("Longitude", "Latitude"),
+    crs = 4326,
+    sfc_name = sfc_name,
+    activate = activate
+  )
 }
 
 #' Convert sfc column to Longitude and Latitude in WGS84.

--- a/R/nearest.R
+++ b/R/nearest.R
@@ -49,7 +49,13 @@ nn1 <- function(x, y) {
 }
 
 #' @export
-ps_nearest.data.frame <- function(x, y, by = c("X", "Y"), dist_col = NULL, ...) {
+ps_nearest.data.frame <- function(
+  x,
+  y,
+  by = c("X", "Y"),
+  dist_col = NULL,
+  ...
+) {
   chk_vector(by)
   check_values(by, "")
   chk_gte(by, 1)
@@ -84,7 +90,9 @@ ps_nearest.data.frame <- function(x, y, by = c("X", "Y"), dist_col = NULL, ...) 
 
   y <- y[nn1$index, ]
 
-  if (!is.null(dist_col)) y[dist_col] <- nn1$distance
+  if (!is.null(dist_col)) {
+    y[dist_col] <- nn1$distance
+  }
 
   rownames <- rownames(x)
   x %<>% cbind(y)
@@ -117,7 +125,9 @@ ps_nearest.sf <- function(x, y, by = c("X", "Y"), dist_col = NULL, ...) {
 
   colnames <- c(colnames(x), colnames(y))
 
-  if (is.sf(y)) y %<>% sf::st_transform(sf::st_crs(x))
+  if (is.sf(y)) {
+    y %<>% sf::st_transform(sf::st_crs(x))
+  }
 
   x %<>%
     as_data_frame() %>%
@@ -151,23 +161,29 @@ ps_nearest.sf <- function(x, y, by = c("X", "Y"), dist_col = NULL, ...) {
 ps_nearest_feature <- function(x, y, dist_col = NULL, ...) {
   check_data(x)
   check_data(y)
-  if (!(is.sf(x) && is.sf(y))) err("`x` and `y` must both be sf objects.")
+  if (!(is.sf(x) && is.sf(y))) {
+    err("`x` and `y` must both be sf objects.")
+  }
   chk_null_or(dist_col, vld = vld_string)
-
 
   x %<>% ps_rename_active_sfc()
   y %<>% ps_rename_active_sfc()
   y %<>% sf::st_transform(sf::st_crs(x))
 
   if (ps_active_sfc_name(y) %in% names(x)) {
-    names(y)[names(y) == ps_active_sfc_name(y)] <- paste0(ps_active_sfc_name(y), ".y")
+    names(y)[names(y) == ps_active_sfc_name(y)] <- paste0(
+      ps_active_sfc_name(y),
+      ".y"
+    )
     st_geometry(y) <- paste0(ps_active_sfc_name(y), ".y")
   }
 
   y <- y[st_nearest_feature(x, y), ]
 
   if (!is.null(dist_col)) {
-    if (dist_col %in% names(x)) err("`dist_col` must not already be present in `names(x)`")
+    if (dist_col %in% names(x)) {
+      err("`dist_col` must not already be present in `names(x)`")
+    }
     x[dist_col] <- st_distance(x, y, by_element = TRUE)
   }
 
@@ -180,7 +196,11 @@ ps_nearest_feature <- function(x, y, dist_col = NULL, ...) {
   sfc_names <- names(x)[sapply(names(x), function(colname) {
     is.sfc(x[colname][[1]])
   })]
-  colnames <- c(names(x)[!names(x) %in% c(sfc_names, dist_col)], dist_col, sfc_names)
+  colnames <- c(
+    names(x)[!names(x) %in% c(sfc_names, dist_col)],
+    dist_col,
+    sfc_names
+  )
   x <- x[colnames]
   x %<>% sf::st_as_sf()
 }

--- a/R/proj.R
+++ b/R/proj.R
@@ -5,8 +5,11 @@
 #' @param crs The projection to use.
 #' @return The modified object
 #' @export
-ps_sfcs_to_crs <- function(x, sfc_names = ps_sfc_names(x),
-                           crs = getOption("ps.crs", 4326)) {
+ps_sfcs_to_crs <- function(
+  x,
+  sfc_names = ps_sfc_names(x),
+  crs = getOption("ps.crs", 4326)
+) {
   if (!all(sfc_names %in% ps_sfc_names(x))) {
     ps_error("missing sfc_names")
   }
@@ -20,7 +23,9 @@ ps_sfcs_to_crs <- function(x, sfc_names = ps_sfc_names(x),
 
   x <- purrr::modify_at(x, .at = sfc_names, .f = sf::st_transform, crs)
 
-  if (length(active_sfc_name)) x %<>% ps_activate_sfc(active_sfc_name)
+  if (length(active_sfc_name)) {
+    x %<>% ps_activate_sfc(active_sfc_name)
+  }
   x
 }
 
@@ -44,7 +49,8 @@ ps_equal_crs <- function(x, sfc_names = ps_sfc_names(x)) {
   x <- x[sfc_names]
   crs <- purrr::map2(x, sfc_names, function(y, z) {
     c <- ps_get_proj4string(y[z])
-  }) %>% unlist()
+  }) %>%
+    unlist()
 
   !length(unique(crs)) > 1
 }
@@ -57,7 +63,9 @@ ps_equal_crs <- function(x, sfc_names = ps_sfc_names(x)) {
 ps_utm_zone <- function(x, sfc_name = ps_active_sfc_name(x)) {
   chk_string(sfc_name)
 
-  if (!sfc_name %in% ps_sfc_names(x)) ps_error("column '", sfc_name, "' is not an sfc column")
+  if (!sfc_name %in% ps_sfc_names(x)) {
+    ps_error("column '", sfc_name, "' is not an sfc column")
+  }
 
   x %<>% ps_sfcs_to_wgs84(sfc_names = sfc_name)
 
@@ -69,17 +77,13 @@ ps_utm_zone <- function(x, sfc_name = ps_active_sfc_name(x)) {
   get_zone <- function(lat, long) {
     if (lat >= 56 && lat < 64 && long >= 3 && long < 12) {
       x <- 32
-    } else if (
-      lat >= 72 && lat < 84 && long >= 0 && long < 9) {
+    } else if (lat >= 72 && lat < 84 && long >= 0 && long < 9) {
       x <- 31
-    } else if (
-      lat >= 72 && lat < 84 && long >= 9 && long < 21) {
+    } else if (lat >= 72 && lat < 84 && long >= 9 && long < 21) {
       x <- 33
-    } else if (
-      lat >= 72 && lat < 84 && long >= 21 && long < 33) {
+    } else if (lat >= 72 && lat < 84 && long >= 21 && long < 33) {
       x <- 35
-    } else if (
-      lat >= 72 && lat < 84 && long >= 33 && long < 42) {
+    } else if (lat >= 72 && lat < 84 && long >= 33 && long < 42) {
       x <- 37
     } else {
       x <- (floor((long + 180) / 6) %% 60) + 1
@@ -96,15 +100,32 @@ ps_utm_zone <- function(x, sfc_name = ps_active_sfc_name(x)) {
 #' @param datum A character string indicating desired datum of UTM proj4string.
 #'
 #' @return A numeric vector of UTM zone(s).
-ps_utm_proj4string <- function(x, sfc_name = ps_active_sfc_name(x), datum = "WGS84") {
+ps_utm_proj4string <- function(
+  x,
+  sfc_name = ps_active_sfc_name(x),
+  datum = "WGS84"
+) {
   zone <- ps_utm_zone(x, sfc_name)
   lat <- ps_sfc_to_coords(x[sfc_name])$Y
 
   prj <- purrr::map2_chr(zone, lat, function(y, z) {
     if (z >= 0) {
-      paste0("+proj=utm +zone=", y, " +datum=", datum, " +units=m +no_defs +type=crs")
+      paste0(
+        "+proj=utm +zone=",
+        y,
+        " +datum=",
+        datum,
+        " +units=m +no_defs +type=crs"
+      )
     } else {
-      paste0("+proj=utm +zone=", y, " +south", " +datum=", datum, " +units=m +no_defs +type=crs")
+      paste0(
+        "+proj=utm +zone=",
+        y,
+        " +south",
+        " +datum=",
+        datum,
+        " +units=m +no_defs +type=crs"
+      )
     }
   })
   prj

--- a/R/read-tracks-gpx.R
+++ b/R/read-tracks-gpx.R
@@ -8,7 +8,11 @@
 #' @return An sf object with a tibble of the datetime and a sfc_POINT geometry of three dimensional points where the third dimension is the elevation in m.
 #' @seealso ps_read_tracks_gpxs
 #' @export
-ps_read_tracks_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = getOption("ps.crs", 4326)) {
+ps_read_tracks_gpx <- function(
+  file,
+  tz = getOption("ps.tz", "UTC"),
+  crs = getOption("ps.crs", 4326)
+) {
   chk_string(file)
 
   if (!file.exists(file)) {
@@ -23,7 +27,10 @@ ps_read_tracks_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = getOp
     stop("file '", file, "' does not contain tracks", call. = FALSE)
   }
 
-  names(gpx) <- vapply(gpx, xml_value, character(1),
+  names(gpx) <- vapply(
+    gpx,
+    xml_value,
+    character(1),
     name = "name",
     USE.NAMES = FALSE
   )
@@ -31,7 +38,10 @@ ps_read_tracks_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = getOp
     lapply(magrittr::extract2, "trkseg") %>%
     purrr::imap(xml_trkseg_data_frame) %>%
     do.call(rbind, .) %>%
-    sf::st_as_sf(coords = c("longitude", "latitude", "elevation"), crs = 4326) %>%
+    sf::st_as_sf(
+      coords = c("longitude", "latitude", "elevation"),
+      crs = 4326
+    ) %>%
     sf::st_transform(crs = crs)
 
   gpx$datetime %<>% lubridate::with_tz(tz)
@@ -49,9 +59,13 @@ ps_read_tracks_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = getOp
 #' @return An sf object with a tibble of the datetime (POSIXct) and the file path (character) and a sfc_POINT geometry of three dimensional points where the third dimension is the elevation in m.
 #' @seealso ps_read_tracks_gpx
 #' @export
-ps_read_tracks_gpxs <- function(dir, pattern = "[.]gpx$", recursive = FALSE,
-                                tz = getOption("ps.tz", "UTC"),
-                                crs = getOption("ps.crs", 4326)) {
+ps_read_tracks_gpxs <- function(
+  dir,
+  pattern = "[.]gpx$",
+  recursive = FALSE,
+  tz = getOption("ps.tz", "UTC"),
+  crs = getOption("ps.crs", 4326)
+) {
   chk_string(dir)
   chk_string(pattern)
   chk_flag(recursive)
@@ -60,10 +74,17 @@ ps_read_tracks_gpxs <- function(dir, pattern = "[.]gpx$", recursive = FALSE,
     stop("directory '", dir, "' does not exist", call. = FALSE)
   }
 
-  files <- list.files(dir, pattern = pattern, recursive = recursive, full.names = TRUE)
+  files <- list.files(
+    dir,
+    pattern = pattern,
+    recursive = recursive,
+    full.names = TRUE
+  )
   sfiles <- list.files(dir, pattern = pattern, recursive = recursive)
 
-  if (!length(files)) stop("there are no gpx files", call. = FALSE)
+  if (!length(files)) {
+    stop("there are no gpx files", call. = FALSE)
+  }
 
   gpx <- lapply(files, ps_read_tracks_gpx, tz = tz, crs = crs) %>%
     stats::setNames(sfiles) %>%

--- a/R/read-waypoints-gpx.R
+++ b/R/read-waypoints-gpx.R
@@ -8,7 +8,11 @@
 #' @return An sf object with a tibble of the datetime and a sfc_POINT geometry of three dimensional points where the third dimension is the elevation in m.
 #' @seealso ps_read_waypoints_gpxs
 #' @export
-ps_read_waypoints_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = getOption("ps.crs", 4326)) {
+ps_read_waypoints_gpx <- function(
+  file,
+  tz = getOption("ps.tz", "UTC"),
+  crs = getOption("ps.crs", 4326)
+) {
   chk_string(file)
 
   if (!file.exists(file)) {
@@ -23,7 +27,10 @@ ps_read_waypoints_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = ge
     stop("file '", file, "' does not contain waypoints", call. = FALSE)
   }
 
-  names(gpx) <- vapply(gpx, xml_value, character(1),
+  names(gpx) <- vapply(
+    gpx,
+    xml_value,
+    character(1),
     name = "time",
     USE.NAMES = FALSE
   )
@@ -48,8 +55,12 @@ ps_read_waypoints_gpx <- function(file, tz = getOption("ps.tz", "UTC"), crs = ge
 #' @return An sf object with a tibble of the datetime (POSIXct) and the file path (character) and a sfc_POINT geometry of three dimensional points where the third dimension is the elevation in m.
 #' @seealso ps_read_waypoints_gpx
 #' @export
-ps_read_waypoints_gpxs <- function(dir, pattern = "[.]gpx$", recursive = FALSE,
-                                   crs = getOption("ps.crs", 4326)) {
+ps_read_waypoints_gpxs <- function(
+  dir,
+  pattern = "[.]gpx$",
+  recursive = FALSE,
+  crs = getOption("ps.crs", 4326)
+) {
   chk_string(dir)
   chk_string(pattern)
   chk_flag(recursive)
@@ -58,10 +69,17 @@ ps_read_waypoints_gpxs <- function(dir, pattern = "[.]gpx$", recursive = FALSE,
     stop("directory '", dir, "' does not exist", call. = FALSE)
   }
 
-  files <- list.files(dir, pattern = pattern, recursive = recursive, full.names = TRUE)
+  files <- list.files(
+    dir,
+    pattern = pattern,
+    recursive = recursive,
+    full.names = TRUE
+  )
   sfiles <- list.files(dir, pattern = pattern, recursive = recursive)
 
-  if (!length(files)) stop("there are no gpx files", call. = FALSE)
+  if (!length(files)) {
+    stop("there are no gpx files", call. = FALSE)
+  }
 
   gpx <- lapply(files, ps_read_waypoints_gpx, crs = crs) %>%
     stats::setNames(sfiles) %>%

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -48,7 +48,9 @@ ps_inactive_sfc_names <- function(x) {
 #' @export
 ps_activate_sfc <- function(x, sfc_name = "geometry") {
   chk_string(sfc_name)
-  if (!sfc_name %in% ps_sfc_names(x)) ps_error("sfc_name must be an sfc column.")
+  if (!sfc_name %in% ps_sfc_names(x)) {
+    ps_error("sfc_name must be an sfc column.")
+  }
 
   if (identical(sfc_name, ps_active_sfc_name(x))) {
     return(x)
@@ -70,7 +72,11 @@ ps_activate_sfc <- function(x, sfc_name = "geometry") {
 #' @export
 #'
 ps_deactivate_sfc <- function(x) {
-  lifecycle::deprecate_soft("0.0.0.9027", "ps_deactivate_sfc()", "tibble::as_tibble()")
+  lifecycle::deprecate_soft(
+    "0.0.0.9027",
+    "ps_deactivate_sfc()",
+    "tibble::as_tibble()"
+  )
 
   if (identical(ps_active_sfc_name(x), character(0))) {
     return(x)
@@ -92,7 +98,9 @@ ps_deactivate_sfc <- function(x) {
 #' @export
 ps_rename_active_sfc <- function(x, new_name = "geometry") {
   active_sfc_name <- ps_active_sfc_name(x)
-  if (!length(active_sfc_name)) ps_error("x does not have an active sfc column")
+  if (!length(active_sfc_name)) {
+    ps_error("x does not have an active sfc column")
+  }
   chk_string(new_name)
 
   if (identical(new_name, active_sfc_name)) {
@@ -116,14 +124,18 @@ ps_rename_active_sfc <- function(x, new_name = "geometry") {
 #' @param sfc_names A character vector indicating the name of the sfc column(s) to remove.
 #' @export
 ps_remove_sfcs <- function(x, sfc_names = ps_sfc_names(x)) {
-  if (!is.data.frame(x)) ps_error("x must be a data.frame")
+  if (!is.data.frame(x)) {
+    ps_error("x must be a data.frame")
+  }
   chk_vector(sfc_names)
   check_values(sfc_names, "")
   if (!any(sfc_names %in% ps_sfc_names(x))) {
     return(x)
   }
 
-  if (ps_active_sfc_name(x) %in% sfc_names) x %<>% tibble::as_tibble()
+  if (ps_active_sfc_name(x) %in% sfc_names) {
+    x %<>% tibble::as_tibble()
+  }
 
   sfc_names %<>% intersect(ps_sfc_names(x))
   x <- x[, setdiff(colnames(x), sfc_names)]

--- a/R/transform.R
+++ b/R/transform.R
@@ -13,16 +13,25 @@
 #' @param out_pattern A string of the extension specifying which file format output files will be saved to.
 #' @return Files with specified crs and extension written to output directory.
 #' @export
-ps_batch_transform <- function(in_dir, out_dir,
-                               recursive = T,
-                               in_pattern = "[.]shp$",
-                               out_pattern = ".sqlite",
-                               in_crs = NULL, out_crs = NULL) {
+ps_batch_transform <- function(
+  in_dir,
+  out_dir,
+  recursive = T,
+  in_pattern = "[.]shp$",
+  out_pattern = ".sqlite",
+  in_crs = NULL,
+  out_crs = NULL
+) {
   if (!(dir.exists(out_dir))) {
     dir.create(out_dir)
   }
 
-  filex <- list.files(path = in_dir, full.names = T, recursive = recursive, pattern = in_pattern)
+  filex <- list.files(
+    path = in_dir,
+    full.names = T,
+    recursive = recursive,
+    pattern = in_pattern
+  )
 
   pb <- txtProgressBar(min = 0, max = length(filex), style = 3)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -129,5 +129,9 @@ xml_wpt_data_frame <- function(x, wpt) {
 }
 
 warn_geom_non_point <- function(x) {
-  if (!all(sf::st_geometry_type(x) %in% c("POINT", "MULTIPOINT"))) ps_warning("Distance calculation uses nearest vertex for non-point geometries. Use `ps_nearest_feature` for calculating nearest feature boundary for lines and polygons.")
+  if (!all(sf::st_geometry_type(x) %in% c("POINT", "MULTIPOINT"))) {
+    ps_warning(
+      "Distance calculation uses nearest vertex for non-point geometries. Use `ps_nearest_feature` for calculating nearest feature boundary for lines and polygons."
+    )
+  }
 }

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-add-z.R
+++ b/tests/testthat/test-add-z.R
@@ -14,8 +14,7 @@ test_that("elevation data can be added to a specified sfc column", {
   expect_true(inherits(ptz2$geometry[[1]], "XYZ"))
   expect_true(!inherits(ptz$geometry[[1]], "XYZ"))
   # must have correct x_column
-  expect_error(ptz %<>% rename(Elev = Elvation) %>%
-    ps_sfc_add_z())
+  expect_error(ptz %<>% rename(Elev = Elvation) %>% ps_sfc_add_z())
   # check works if units not set
   pt <- readRDS(system.file("sf/pt.rds", package = "poisspatial"))
   pt$Elevation <- c(1, 100, 200)

--- a/tests/testthat/test-basemap.R
+++ b/tests/testthat/test-basemap.R
@@ -34,14 +34,23 @@ test_that("basemap related functions work", {
   expect_identical(length(sf::st_cast(sfc, "POINT")), 5L)
 
   sfc2 <- ps_create_bounds(sf::st_transform(poly, 26911), c(10, 100, 200, 500))
-  expect_error(ps_create_bounds(sf::st_transform(poly, 26911), c(10, 100, "b", 500)))
+  expect_error(ps_create_bounds(
+    sf::st_transform(poly, 26911),
+    c(10, 100, "b", 500)
+  ))
   expect_is(sfc2, "sfc")
   expect_true(!is_longlat(sfc2))
   expect_identical(sf::st_crs(sfc2), sf::st_crs(sf::st_transform(poly, 26911)))
   expect_identical(length(sfc2), 1L)
   expect_identical(length(sf::st_cast(sfc2, "POINT")), 5L)
-  expect_identical(sf::st_bbox(sf::st_transform(poly, 26911))[[1]] - 10, sf::st_coordinates(sfc2)[1, 1][[1]])
-  expect_identical(sf::st_bbox(sf::st_transform(poly, 26911))[[3]] + 200, sf::st_coordinates(sfc2)[3, 1][[1]])
+  expect_identical(
+    sf::st_bbox(sf::st_transform(poly, 26911))[[1]] - 10,
+    sf::st_coordinates(sfc2)[1, 1][[1]]
+  )
+  expect_identical(
+    sf::st_bbox(sf::st_transform(poly, 26911))[[3]] + 200,
+    sf::st_coordinates(sfc2)[3, 1][[1]]
+  )
 
   # ggmap <- ps_bbox_ggmap(x = bbox2, "google", "satellite")
   # expect_is(ggmap, "ggmap")

--- a/tests/testthat/test-centroid.R
+++ b/tests/testthat/test-centroid.R
@@ -71,7 +71,10 @@ test_that("centroid1", {
   expect_identical(colnames(cent.pt), c("color", "geometry"))
 
   expect_equal(ps_sfc_to_coords(cent.pt)$X, ps_sfc_to_coords(cent.pt)$X)
-  expect_equal(ps_sfc_to_coords(cent.pt)$Y, c(50.006919103519, 50.0052414257851))
+  expect_equal(
+    ps_sfc_to_coords(cent.pt)$Y,
+    c(50.006919103519, 50.0052414257851)
+  )
 
   cent.pt <- ps_sfc_centroid1(pt, nearest = TRUE)
   expect_true(inherits(cent.pt$geometry, "sfc_POINT"))
@@ -86,8 +89,14 @@ test_that("centroid1", {
   expect_true(inherits(cent.pt, "sf"))
   expect_identical(sf::st_crs(cent.pt), sf::st_crs(pt))
   expect_identical(colnames(cent.pt), c("color", "geometry"))
-  expect_equal(sort(ps_sfc_to_coords(cent.pt)$X), c(-117.0655727986, -117.0645996034))
-  expect_equal(sort(ps_sfc_to_coords(cent.pt)$Y), c(50.00421134984, 50.00691910352))
+  expect_equal(
+    sort(ps_sfc_to_coords(cent.pt)$X),
+    c(-117.0655727986, -117.0645996034)
+  )
+  expect_equal(
+    sort(ps_sfc_to_coords(cent.pt)$Y),
+    c(50.00421134984, 50.00691910352)
+  )
 
   pt <- rbind(pt, pt[pt$id == 2, ])
 
@@ -97,12 +106,18 @@ test_that("centroid1", {
   expect_true(inherits(cent.pt, "sf"))
   expect_identical(sf::st_crs(cent.pt), sf::st_crs(pt))
   expect_identical(colnames(cent.pt), c("color", "geometry"))
-  expect_equal(ps_sfc_to_coords(cent.pt)$X, c(495371.000000044, 495345.000000045))
+  expect_equal(
+    ps_sfc_to_coords(cent.pt)$X,
+    c(495371.000000044, 495345.000000045)
+  )
 
   cent.pt <- ps_sfc_centroid1(pt, by = "color", nearest = TRUE)
   expect_true(inherits(cent.pt$geometry, "sfc_POINT"))
   expect_true(inherits(cent.pt, "sf"))
   expect_identical(sf::st_crs(cent.pt), sf::st_crs(pt))
   expect_identical(colnames(cent.pt), c("color", "geometry"))
-  expect_equal(ps_sfc_to_coords(cent.pt)$X, c(495371.000000044, 495367.000000045))
+  expect_equal(
+    ps_sfc_to_coords(cent.pt)$X,
+    c(495371.000000044, 495367.000000045)
+  )
 })

--- a/tests/testthat/test-coords.R
+++ b/tests/testthat/test-coords.R
@@ -8,7 +8,10 @@ test_that("ps_coords_to_sfc when missnig values", {
   y2 <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE)
   expect_identical(y[c(1, 3), ], y2[c(1, 3), ])
   expect_identical(y[, 1], y2[, 1])
-  expect_identical(y2$geometry[[2]], structure(c(NA_real_, NA_real_), class = c("XY", "POINT", "sfg")))
+  expect_identical(
+    y2$geometry[[2]],
+    structure(c(NA_real_, NA_real_), class = c("XY", "POINT", "sfg"))
+  )
 })
 
 test_that("ps_coords_to_sfc retain_orig flag keeps input columns when TRUE", {
@@ -36,7 +39,11 @@ test_that("ps_sfc_to_coords retain_orig flag keeps input column when TRUE", {
   x$Row <- 2:4
 
   y <- ps_coords_to_sfc(x, crs = 28992, activate = FALSE, retain_orig = TRUE)
-  Y2 <- ps_sfc_to_coords(y[, "geometry"], sfc_name = "geometry", retain_orig = TRUE)
+  Y2 <- ps_sfc_to_coords(
+    y[, "geometry"],
+    sfc_name = "geometry",
+    retain_orig = TRUE
+  )
 
   expect_identical(y$geometry, Y2$geometry)
 })

--- a/tests/testthat/test-elevation.R
+++ b/tests/testthat/test-elevation.R
@@ -8,7 +8,9 @@ test_that("ps_elevation_google", {
   e <- ps_elevation_google(x)
   expect_identical(colnames(e), c("Row", "geometry", "Z"))
   expect_identical(e[c("Row", "geometry")], x[c("Row", "geometry")])
-  expect_equal(e$Z, c(135.154434204102, 135.121871948242, 135.305969238281),
+  expect_equal(
+    e$Z,
+    c(135.154434204102, 135.121871948242, 135.305969238281),
     tolerance = 1e-03
   )
 })
@@ -33,7 +35,9 @@ test_that("ps_elevation_google missing values", {
   e <- ps_elevation_google(x)
   expect_identical(colnames(e), c("Row", "geometry", "Z"))
   expect_identical(e[c("Row", "geometry")], x[c("Row", "geometry")])
-  expect_equal(e$Z, c(135.154434204102, NA, 135.305969238281),
+  expect_equal(
+    e$Z,
+    c(135.154434204102, NA, 135.305969238281),
     tolerance = 1e-03
   )
 })

--- a/tests/testthat/test-load.R
+++ b/tests/testthat/test-load.R
@@ -36,7 +36,14 @@ test_that("rename and fun arguments work", {
     x %<>% sf::st_transform(4326)
   }
   sink(get_null_device())
-  files <- ps_load_spatial(dir, recursive = T, pattern = ".shp", crs = 26911, rename = rename, fun = trans)
+  files <- ps_load_spatial(
+    dir,
+    recursive = T,
+    pattern = ".shp",
+    crs = 26911,
+    rename = rename,
+    fun = trans
+  )
   sink()
   expect_identical(sf::st_crs(yna)$epsg, 4326L)
 })
@@ -50,7 +57,10 @@ test_that("spatial database loads", {
   sink(get_null_device())
   ikeda <- ps_load_spatial_db(path = path, rename = rename, fun = trans)
   sink()
-  expect_identical(sf::st_crs(SITE)$proj4string, "+proj=aea +lat_0=45 +lon_0=-126 +lat_1=50 +lat_2=58.5 +x_0=1000000 +y_0=0 +datum=NAD83 +units=m +no_defs")
+  expect_identical(
+    sf::st_crs(SITE)$proj4string,
+    "+proj=aea +lat_0=45 +lon_0=-126 +lat_1=50 +lat_2=58.5 +x_0=1000000 +y_0=0 +datum=NAD83 +units=m +no_defs"
+  )
   l <- ls()
   expect_true(any(l %in% c("CREEK", "SITE", "IKEDA")))
 })

--- a/tests/testthat/test-nearest-feature.R
+++ b/tests/testthat/test-nearest-feature.R
@@ -1,16 +1,28 @@
 test_that("ps_nearest_feature joins correct feature, manages names and calculates distance", {
-  pt <- sf::st_read(system.file("gpkg/points.gpkg", package = "poisspatial"), quiet = TRUE)
-  poly <- sf::st_read(system.file("gpkg/polygons.gpkg", package = "poisspatial"), quiet = TRUE)
+  pt <- sf::st_read(
+    system.file("gpkg/points.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
+  poly <- sf::st_read(
+    system.file("gpkg/polygons.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
 
   pt2 <- ps_nearest_feature(pt, poly, dist_col = "dist")
 
   expect_equal(as.numeric(pt2$dist), c(0.0000000, 0.4665229))
   expect_identical(pt2$ID, c("b", "a"))
-  expect_identical(names(pt2), c("Number", "ID", "dist", "geometry", "geometry.y"))
+  expect_identical(
+    names(pt2),
+    c("Number", "ID", "dist", "geometry", "geometry.y")
+  )
   expect_identical(ps_active_sfc_name(pt2), "geometry")
 
   pt2 <- ps_nearest_feature(pt, poly, dist_col = "ID")
-  expect_identical(names(pt2), c("Number", "ID.y", "ID", "geometry", "geometry.y"))
+  expect_identical(
+    names(pt2),
+    c("Number", "ID.y", "ID", "geometry", "geometry.y")
+  )
 
   poly_ab <- poly[1:2, ]
   poly_cd <- poly[3:4, ]
@@ -19,16 +31,26 @@ test_that("ps_nearest_feature joins correct feature, manages names and calculate
 
   expect_equal(as.numeric(poly2$dist), c(0.8908796, 5.8361786))
   expect_identical(poly2$ID.y, c("b", "a"))
-  expect_identical(names(poly2), c("ID", "ID.y", "dist", "geometry", "geometry.y"))
+  expect_identical(
+    names(poly2),
+    c("ID", "ID.y", "dist", "geometry", "geometry.y")
+  )
   expect_identical(ps_active_sfc_name(pt2), "geometry")
 })
 
 
 test_that("ps_nearest_feature errors", {
-  pt <- sf::st_read(system.file("gpkg/points.gpkg", package = "poisspatial"), quiet = TRUE)
-  poly <- sf::st_read(system.file("gpkg/polygons.gpkg", package = "poisspatial"), quiet = TRUE)
+  pt <- sf::st_read(
+    system.file("gpkg/points.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
+  poly <- sf::st_read(
+    system.file("gpkg/polygons.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
 
-  expect_error(ps_nearest_feature(poly, pt, dist_col = "ID"),
+  expect_error(
+    ps_nearest_feature(poly, pt, dist_col = "ID"),
     "`dist_col` must not already be present in `names(x)`",
     fixed = TRUE
   )

--- a/tests/testthat/test-nearest.R
+++ b/tests/testthat/test-nearest.R
@@ -88,12 +88,25 @@ test_that("nearest sf with X and Y and reprojection", {
   expect_identical(class(n), c("sf", "data.frame"))
   expect_identical(colnames(n), c("X", "Row", "D", "geometry", "geometry.y"))
   expect_identical(n$geometry, x$geometry)
-  expect_equal(n$D, c(0.999960142739643, 4.99990310533304, 94.1329294416483), tolerance = 1e-05)
+  expect_equal(
+    n$D,
+    c(0.999960142739643, 4.99990310533304, 94.1329294416483),
+    tolerance = 1e-05
+  )
 })
 
 test_that("ps_nearest issues warning for non-point sf objects", {
-  pt <- sf::st_read(system.file("gpkg/points.gpkg", package = "poisspatial"), quiet = TRUE)
-  poly <- sf::st_read(system.file("gpkg/polygons.gpkg", package = "poisspatial"), quiet = TRUE)
+  pt <- sf::st_read(
+    system.file("gpkg/points.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
+  poly <- sf::st_read(
+    system.file("gpkg/polygons.gpkg", package = "poisspatial"),
+    quiet = TRUE
+  )
 
-  expect_warning(ps_nearest(pt, poly), "Distance calculation uses nearest vertex for non-point geometries. Use `ps_nearest_feature` for calculating nearest feature boundary for lines and polygons.")
+  expect_warning(
+    ps_nearest(pt, poly),
+    "Distance calculation uses nearest vertex for non-point geometries. Use `ps_nearest_feature` for calculating nearest feature boundary for lines and polygons."
+  )
 })

--- a/tests/testthat/test-proj.R
+++ b/tests/testthat/test-proj.R
@@ -3,7 +3,10 @@ test_that("works", {
   expect_true(!ps_equal_crs(pt))
   pt %<>% ps_sfcs_to_wgs84()
   expect_true(ps_equal_crs(pt))
-  expect_identical(ps_get_proj4string(pt$geometry), "+proj=longlat +datum=WGS84 +no_defs")
+  expect_identical(
+    ps_get_proj4string(pt$geometry),
+    "+proj=longlat +datum=WGS84 +no_defs"
+  )
 
   poly <- readRDS(system.file("sf/poly.rds", package = "poisspatial")) %>%
     ps_sfcs_to_wgs84()
@@ -22,8 +25,14 @@ test_that("works", {
   y <- ps_sfcs_to_crs(pt, crs = 26911)
   z <- ps_sfcs_to_crs(pt, sfc_names = "geometry", crs = 26911)
 
-  expect_identical(sf::st_crs(y$geometry.2)$proj4string, sf::st_crs(z$geometry)$proj4string)
-  expect_identical(sf::st_crs(y$geometry.2)$proj4string, sf::st_crs(y$geometry)$proj4string)
+  expect_identical(
+    sf::st_crs(y$geometry.2)$proj4string,
+    sf::st_crs(z$geometry)$proj4string
+  )
+  expect_identical(
+    sf::st_crs(y$geometry.2)$proj4string,
+    sf::st_crs(y$geometry)$proj4string
+  )
 
   x <- ps_sfcs_to_utm(pt)
   y <- ps_sfcs_to_utm(pt, sfc_names = "geometry.2")

--- a/tests/testthat/test-read-tracks-gpxs.R
+++ b/tests/testthat/test-read-tracks-gpxs.R
@@ -1,10 +1,17 @@
 test_that("works", {
-  tracks <- ps_read_tracks_gpxs(system.file("gpx", package = "poisspatial"), tz = "PST8PDT", recursive = TRUE)
+  tracks <- ps_read_tracks_gpxs(
+    system.file("gpx", package = "poisspatial"),
+    tz = "PST8PDT",
+    recursive = TRUE
+  )
 
   expect_is(tracks, "sf")
   expect_identical(names(tracks), c("File", "Track", "DateTime", "geometry"))
   expect_identical(nrow(tracks), 29306L)
   expect_identical(lubridate::tz(tracks$DateTime), "PST8PDT")
   expect_identical(lubridate::hour(tracks$DateTime[1]), 21L)
-  expect_identical(sort(unique(tracks$File)), sort(c("20110401.gpx", "20110402.gpx", "sub2/20110403.gpx")))
+  expect_identical(
+    sort(unique(tracks$File)),
+    sort(c("20110401.gpx", "20110402.gpx", "sub2/20110403.gpx"))
+  )
 })

--- a/tests/testthat/test-read-waypoints-gpx.R
+++ b/tests/testthat/test-read-waypoints-gpx.R
@@ -1,8 +1,14 @@
 test_that("works", {
-  wpts <- ps_read_waypoints_gpxs(system.file("gpx_wpt", package = "poisspatial"), recursive = TRUE)
+  wpts <- ps_read_waypoints_gpxs(
+    system.file("gpx_wpt", package = "poisspatial"),
+    recursive = TRUE
+  )
 
   expect_is(wpts, "sf")
   expect_identical(names(wpts), c("File", "Waypoint", "geometry"))
   expect_identical(nrow(wpts), 42L)
-  expect_identical(sort(unique(wpts$File)), sort(c("wptgpx1.gpx", "wptgpx2.gpx", "sub2/wptgpx3.gpx")))
+  expect_identical(
+    sort(unique(wpts$File)),
+    sort(c("wptgpx1.gpx", "wptgpx2.gpx", "sub2/wptgpx3.gpx"))
+  )
 })

--- a/tests/testthat/test-sfc.R
+++ b/tests/testthat/test-sfc.R
@@ -46,7 +46,12 @@ test_that("manipulate geometry column", {
   ### test when Z column
   x <- data.frame(X = c(1, 1, 10), Y = c(1, 10, 1), Z = c(1, 1, 1))
   x$Row <- 2:4
-  x <- ps_coords_to_sfc(x, crs = 28992, coords = c("X", "Y", "Z"), activate = TRUE)
+  x <- ps_coords_to_sfc(
+    x,
+    crs = 28992,
+    coords = c("X", "Y", "Z"),
+    activate = TRUE
+  )
   expect_length(colnames(sf::st_coordinates(x)), 3L)
   y <- ps_sfc_to_coords(x)
   expect_true("Z" %in% names(y))

--- a/tests/testthat/test-transform.R
+++ b/tests/testthat/test-transform.R
@@ -5,7 +5,12 @@ test_that("batch transform", {
   dir.create("in")
   sf::st_write(x, "in/x.shp", quiet = TRUE)
   sink(get_null_device())
-  ps_batch_transform(in_dir = "in/", out_dir = "out/", in_crs = 28992, out_crs = 4326)
+  ps_batch_transform(
+    in_dir = "in/",
+    out_dir = "out/",
+    in_crs = 28992,
+    out_crs = 4326
+  )
   sink(get_null_device())
   l <- list.files("out")
   expect_true(!identical(length(l), 0L))


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)